### PR TITLE
Fix composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
             "url": "http://packages.zendframework.com/"
         }
     ],
-    "target-dir": "Zend/Amf",
     "require": {
         "php": ">=5.3.3"
     }


### PR DESCRIPTION
Remove Target-dir entry, it is not playing well with PSR-0 autoloaders. 

If this is not the ZendAmf we should be using can you please point me in the right direction as I am unable to find another usability replica. Applying this fix would help us to deploy with an official dependency instead of referencing my repository. 

Thank you for your consideration...
