### PR TITLE
fixed namespace reference for constants

### DIFF
--- a/library/ZendAmf/Parser/Amf3/Deserializer.php
+++ b/library/ZendAmf/Parser/Amf3/Deserializer.php
@@ -11,7 +11,7 @@
 namespace ZendAmf\Parser\Amf3;
 
 use DateTime;
-use Zend\Amf;
+use ZendAmf as Amf;
 use ZendAmf\Parser;
 use ZendAmf\Parser\AbstractDeserializer;
 


### PR DESCRIPTION
readTypeMarker() would otherwise error as "Class 'Zend\Amf\Constants' not found"